### PR TITLE
swagger修正・削除

### DIFF
--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -554,8 +554,6 @@ paths:
               $ref: "#/components/headers/uid"
             client:
               $ref: "#/components/headers/client"
-            expiry:
-              $ref: "#/components/headers/expiry"
         422:
           $ref: "#/components/responses/UnprocessableEntity"
         500:
@@ -584,8 +582,6 @@ paths:
               $ref: "#/components/headers/uid"
             client:
               $ref: "#/components/headers/client"
-            expiry:
-              $ref: "#/components/headers/expiry"
         401:
           $ref: "#/components/responses/Unauthorized"
         500:
@@ -663,10 +659,6 @@ components:
         type: string
     client:
       description: 異なるクライアントで認証を行うために使用する
-      schema:
-        type: string
-    expiry:
-      description: セッションが期限切れとなる日付
       schema:
         type: string
   schemas:

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -1002,7 +1002,7 @@ components:
                 description: 確認用パスワード
                 example: password
     SignInBody:
-      description: ログイン
+      description: サインイン
       content:
         application/json:
           schema:

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -554,6 +554,8 @@ paths:
               $ref: "#/components/headers/uid"
             client:
               $ref: "#/components/headers/client"
+            expiry:
+              $ref: "#/components/headers/expiry"
         422:
           $ref: "#/components/responses/UnprocessableEntity"
         500:
@@ -582,6 +584,8 @@ paths:
               $ref: "#/components/headers/uid"
             client:
               $ref: "#/components/headers/client"
+            expiry:
+              $ref: "#/components/headers/expiry"
         401:
           $ref: "#/components/responses/Unauthorized"
         500:
@@ -659,6 +663,10 @@ components:
         type: string
     client:
       description: 異なるクライアントで認証を行うために使用する
+      schema:
+        type: string
+    expiry:
+      description: セッションが期限切れとなる日付
       schema:
         type: string
   schemas:

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -549,17 +549,11 @@ paths:
                 $ref: "#/components/schemas/User"
           headers:
             access-token:
-              schema:
-                type: string
-              description: パスワードとして機能する
+              $ref: "#/components/headers/access-token"
             uid:
-              schema:
-                type: string
-              description: ユーザーを識別するために使用する
+              $ref: "#/components/headers/uid"
             client:
-              schema:
-                type: string
-              description: 異なるクライアントで認証を行うために使用する
+              $ref: "#/components/headers/client"
         422:
           $ref: "#/components/responses/UnprocessableEntity"
         500:
@@ -583,17 +577,11 @@ paths:
                 $ref: "#/components/schemas/User"
           headers:
             access-token:
-              schema:
-                type: string
-              description: パスワードとして機能する
+              $ref: "#/components/headers/access-token"
             uid:
-              schema:
-                type: string
-              description: ユーザーを識別するために使用する
+              $ref: "#/components/headers/uid"
             client:
-              schema:
-                type: string
-              description: 異なるクライアントで認証を行うために使用する
+              $ref: "#/components/headers/client"
         401:
           $ref: "#/components/responses/Unauthorized"
         500:
@@ -660,6 +648,19 @@ components:
             $ref: "#/components/schemas/Error"
           example:
             message: サーバーでエラーが発生しています
+  headers:
+    access-token:
+      description: パスワードとして機能する
+      schema:
+        type: string
+    uid:
+      description: ユーザーを識別するために使用する
+      schema:
+        type: string
+    client:
+      description: 異なるクライアントで認証を行うために使用する
+      schema:
+        type: string
   schemas:
     Error:
       description: エラー

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -4,7 +4,7 @@ info:
   title: dutch_account_app
   description: 割り勘アプリ
 servers:
-  - url: http://localhost:3000/api
+  - url: http://localhost:8000/api/v1
     description: 開発環境
 tags:
   - name: paymentGroup
@@ -541,6 +541,10 @@ paths:
       responses:
         200:
           description: サインアップに成功した時のレスポンス
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
           headers:
             access-token:
               schema:
@@ -554,10 +558,6 @@ paths:
               schema:
                 type: string
               description: 異なるクライアントで認証を行うために使用する
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
         422:
           $ref: "#/components/responses/UnprocessableEntity"
         500:
@@ -575,6 +575,10 @@ paths:
       responses:
         200:
           description: サインインに成功した時のレスポンス
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
           headers:
             access-token:
               schema:
@@ -588,10 +592,6 @@ paths:
               schema:
                 type: string
               description: 異なるクライアントで認証を行うために使用する
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
         401:
           $ref: "#/components/responses/Unauthorized"
         500:

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -615,7 +615,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: リクエストパラメーターに不備があります
+            message: [リクエストパラメーターに不備があります]
     Unauthorized:
       description: 認証されていない時のレスポンス
       content:
@@ -623,7 +623,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: アクセス権限がありません
+            message: [アクセス権限がありません]
     NotFound:
       description: リクエストされたリソースが存在しない時のレスポンス
       content:
@@ -631,7 +631,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: ページが見つかりません
+            message: [ページが見つかりません]
     UnprocessableEntity:
       description: リクエストされた指示を処理できなかった時のレスポンス
       content:
@@ -639,7 +639,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: このアカウントはすでに存在しています
+            message: [このアカウントはすでに存在しています]
     InternalServerError:
       description: サーバーでエラーが発生している時のレスポンス
       content:
@@ -647,7 +647,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: サーバーでエラーが発生しています
+            message: [サーバーでエラーが発生しています]
   headers:
     access-token:
       description: パスワードとして機能する
@@ -669,8 +669,11 @@ components:
         - message
       properties:
         message:
-          type: string
+          type: array
+          items:
+            type: string
           description: エラーメッセージ
+          example: エラーが発生しました
     User:
       description: ユーザー
       type: object

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -13,7 +13,9 @@ tags:
   - name: remittanceRecord
   - name: user
 security:
-  - DeviseTokenAuth: []
+  - accessToken: []
+    uid: []
+    client: []
 paths:
   /payment_groups:
     get:
@@ -1083,6 +1085,15 @@ components:
         format: int64
         example: 1
   securitySchemes:
-    DeviseTokenAuth:
-      type: http
-      scheme: bearer
+    accessToken:
+      type: apiKey
+      in: header
+      name: access-token
+    uid:
+      type: apiKey
+      in: header
+      name: uid
+    client:
+      type: apiKey
+      in: header
+      name: client

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -615,7 +615,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: [リクエストパラメーターに不備があります]
+            messages: [リクエストパラメーターに不備があります]
     Unauthorized:
       description: 認証されていない時のレスポンス
       content:
@@ -623,7 +623,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: [アクセス権限がありません]
+            messages: [アクセス権限がありません]
     NotFound:
       description: リクエストされたリソースが存在しない時のレスポンス
       content:
@@ -631,7 +631,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: [ページが見つかりません]
+            messages: [ページが見つかりません]
     UnprocessableEntity:
       description: リクエストされた指示を処理できなかった時のレスポンス
       content:
@@ -639,7 +639,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: [このアカウントはすでに存在しています]
+            messages: [このアカウントはすでに存在しています]
     InternalServerError:
       description: サーバーでエラーが発生している時のレスポンス
       content:
@@ -647,7 +647,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            message: [サーバーでエラーが発生しています]
+            messages: [サーバーでエラーが発生しています]
   headers:
     access-token:
       description: パスワードとして機能する
@@ -666,9 +666,9 @@ components:
       description: エラー
       type: object
       required:
-        - message
+        - messages
       properties:
-        message:
+        messages:
           type: array
           items:
             type: string

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -599,7 +599,6 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            code: 400
             message: リクエストパラメーターに不備があります
     Unauthorized:
       description: 認証されていない時のレスポンス
@@ -608,7 +607,6 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            code: 401
             message: アクセス権限がありません
     NotFound:
       description: リクエストされたリソースが存在しない時のレスポンス
@@ -617,7 +615,6 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            code: 404
             message: ページが見つかりません
     UnprocessableEntity:
       description: リクエストされた指示を処理できなかった時のレスポンス
@@ -626,7 +623,6 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            code: 422
             message: このアカウントはすでに存在しています
     InternalServerError:
       description: サーバーでエラーが発生している時のレスポンス
@@ -635,19 +631,14 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
-            code: 500
             message: サーバーでエラーが発生しています
   schemas:
     Error:
       description: エラー
       type: object
       required:
-        - code
         - message
       properties:
-        code:
-          type: string
-          description: HTTPステータスコード
         message:
           type: string
           description: エラーメッセージ

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -541,6 +541,19 @@ paths:
       responses:
         200:
           description: サインアップに成功した時のレスポンス
+          headers:
+            access-token:
+              schema:
+                type: string
+              description: パスワードとして機能する
+            uid:
+              schema:
+                type: string
+              description: ユーザーを識別するために使用する
+            client:
+              schema:
+                type: string
+              description: 異なるクライアントで認証を行うために使用する
           content:
             application/json:
               schema:
@@ -562,6 +575,19 @@ paths:
       responses:
         200:
           description: サインインに成功した時のレスポンス
+          headers:
+            access-token:
+              schema:
+                type: string
+              description: パスワードとして機能する
+            uid:
+              schema:
+                type: string
+              description: ユーザーを識別するために使用する
+            client:
+              schema:
+                type: string
+              description: 異なるクライアントで認証を行うために使用する
           content:
             application/json:
               schema:

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -7,116 +7,14 @@ servers:
   - url: http://localhost:3000/api
     description: 開発環境
 tags:
-  - name: user
   - name: paymentGroup
   - name: userPaymentGroup
   - name: purchaseRecord
   - name: remittanceRecord
-  - name: admin
+  - name: user
 security:
-  - cookieAuth: []
+  - DeviseTokenAuth: []
 paths:
-  /users:
-    get:
-      tags:
-        - user
-      summary: 全ユーザー取得
-      description: 全てのユーザーを取得する
-      operationId: getUsers
-      responses:
-        200:
-          description: 取得が成功した時のレスポンス
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/User"
-        401:
-          $ref: "#/components/responses/Unauthorized"
-        500:
-          $ref: "#/components/responses/InternalServerError"
-    post:
-      tags:
-        - user
-      summary: ユーザー作成
-      description: ユーザーを作成する
-      operationId: addUser
-      requestBody:
-        $ref: "#/components/requestBodies/UserBody"
-      responses:
-        201:
-          description: 作成が成功した時のレスポンス
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
-        400:
-          $ref: "#/components/responses/BadRequest"
-        401:
-          $ref: "#/components/responses/Unauthorized"
-        500:
-          $ref: "#/components/responses/InternalServerError"
-  /users/{user_id}:
-    parameters:
-      - $ref: "#/components/parameters/UserId"
-    get:
-      tags:
-        - user
-      summary: ユーザー取得
-      description: ユーザーIDでユーザーを取得する
-      operationId: getUserByUserId
-      responses:
-        200:
-          description: 取得が成功した時のレスポンス
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
-        401:
-          $ref: "#/components/responses/Unauthorized"
-        404:
-          $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/InternalServerError"
-    put:
-      tags:
-        - user
-      summary: ユーザー更新
-      description: ユーザーIDでユーザーを更新する
-      operationId: updateUserByUserId
-      requestBody:
-        $ref: "#/components/requestBodies/UserBody"
-      responses:
-        200:
-          description: 更新が成功した時のレスポンス
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
-        400:
-          $ref: "#/components/responses/BadRequest"
-        401:
-          $ref: "#/components/responses/Unauthorized"
-        404:
-          $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/InternalServerError"
-    delete:
-      tags:
-        - user
-      summary: ユーザー削除
-      description: ユーザーIDでユーザーを削除する
-      operationId: deleteUserByUserId
-      responses:
-        204:
-          $ref: "#/components/responses/NoContent"
-        401:
-          $ref: "#/components/responses/Unauthorized"
-        404:
-          $ref: "#/components/responses/NotFound"
-        500:
-          $ref: "#/components/responses/InternalServerError"
   /payment_groups:
     get:
       tags:
@@ -633,7 +531,7 @@ paths:
   /sign_up:
     post:
       tags:
-        - admin
+        - user
       summary: サインアップ
       description: サインアップする
       operationId: signUp
@@ -641,40 +539,41 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/SignUpBody"
       responses:
-        204:
+        200:
           $ref: "#/components/responses/NoContent"
-        400:
-          $ref: "#/components/responses/BadRequest"
+        422:
+          $ref: "#/components/responses/UnprocessableEntity"
         500:
           $ref: "#/components/responses/InternalServerError"
-  /log_in:
+  /sign_in:
     post:
       tags:
-        - admin
-      summary: ログイン
-      description: ログインする
-      operationId: logIn
+        - user
+      summary: サインイン
+      description: サインインする
+      operationId: signIn
       security: []
       requestBody:
-        $ref: "#/components/requestBodies/LogInBody"
+        $ref: "#/components/requestBodies/SignInBody"
       responses:
-        204:
+        200:
           $ref: "#/components/responses/NoContent"
-        400:
-          $ref: "#/components/responses/BadRequest"
+        401:
+          $ref: "#/components/responses/Unauthorized"
         500:
           $ref: "#/components/responses/InternalServerError"
-  /log_out:
+  /sign_out:
     post:
       tags:
-        - admin
-      summary: ログアウト
-      description: ログアウトする
-      operationId: logOut
-      security: []
+        - user
+      summary: サインアウト
+      description: サインアウトする
+      operationId: signOut
       responses:
-        204:
+        200:
           $ref: "#/components/responses/NoContent"
+        404:
+          $ref: "#/components/responses/NotFound"
         500:
           $ref: "#/components/responses/InternalServerError"
 components:
@@ -710,6 +609,15 @@ components:
           example:
             code: 404
             message: ページが見つかりません
+    UnprocessableEntity:
+      description: リクエストされた指示を処理できなかった時のレスポンス
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            code: 422
+            message: このアカウントはすでに存在しています
     InternalServerError:
       description: サーバーでエラーが発生している時のレスポンス
       content:
@@ -1042,10 +950,11 @@ components:
               - name
               - email
               - password
+              - password_confirmation
             properties:
               name:
                 type: string
-                description: 管理者名
+                description: ユーザー名
                 example: 太郎
               email:
                 type: string
@@ -1057,7 +966,12 @@ components:
                 format: password
                 description: パスワード
                 example: password
-    LogInBody:
+              password_confirmation:
+                type: string
+                format: password
+                description: 確認用パスワード
+                example: password
+    SignInBody:
       description: ログイン
       content:
         application/json:
@@ -1142,7 +1056,6 @@ components:
         format: int64
         example: 1
   securitySchemes:
-    cookieAuth:
-      type: apiKey
-      in: cookie
-      name: ADMIN
+    DeviseTokenAuth:
+      type: http
+      scheme: bearer

--- a/server/openapi.yml
+++ b/server/openapi.yml
@@ -540,7 +540,11 @@ paths:
         $ref: "#/components/requestBodies/SignUpBody"
       responses:
         200:
-          $ref: "#/components/responses/NoContent"
+          description: サインアップに成功した時のレスポンス
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
         422:
           $ref: "#/components/responses/UnprocessableEntity"
         500:
@@ -557,7 +561,11 @@ paths:
         $ref: "#/components/requestBodies/SignInBody"
       responses:
         200:
-          $ref: "#/components/responses/NoContent"
+          description: サインインに成功した時のレスポンス
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
         401:
           $ref: "#/components/responses/Unauthorized"
         500:
@@ -571,7 +579,9 @@ paths:
       operationId: signOut
       responses:
         200:
-          $ref: "#/components/responses/NoContent"
+          description: サインアウトに成功した時のレスポンス
+          content:
+            {}
         404:
           $ref: "#/components/responses/NotFound"
         500:


### PR DESCRIPTION
## やったこと
* Adminモデル削除
* Userモデルでログイン出来るよう修正

## 補足
* `schemas/Error/code`の削除
  * `4xx`などのエラーが起こった際には`code`と`message`を返していた
  * しかし、`code`の値はステータスコードと同じ値であり、不要なため削除した
* 認証処理のステータスコード
  * 今回認証には`devise_token_auth`を使用する
  * サインアップなどの成功・失敗時のステータスコードを`devise_token_auth`で定められている値に修正した 

## swagger
* `/sign_up`
![image](https://user-images.githubusercontent.com/73219274/188274624-4343fbea-2ceb-4483-81d0-6f3c85e0c9d2.png)
![image](https://user-images.githubusercontent.com/73219274/188274632-1351c44e-0034-44f5-9854-cac2f939eb97.png)
![image](https://user-images.githubusercontent.com/73219274/188274636-aca563e5-7e08-42d2-98b5-143eb22e4c91.png)

* `/sign_in`
![image](https://user-images.githubusercontent.com/73219274/188274785-17d409b2-2ddf-4289-8c2c-4b67a0000117.png)
![image](https://user-images.githubusercontent.com/73219274/188274653-b15e94cd-f4df-4ea4-b426-a6f2e89fabdf.png)
![image](https://user-images.githubusercontent.com/73219274/188274660-75423a8f-e68a-4d95-86a0-f4ae190171d6.png)

* `sign_our`
![image](https://user-images.githubusercontent.com/73219274/188274682-fc5ea457-e070-4be7-b6b7-3af8dc509075.png)